### PR TITLE
Create label-mergeconflicts.yml

### DIFF
--- a/.github/label-mergeconflicts.yml
+++ b/.github/label-mergeconflicts.yml
@@ -1,0 +1,13 @@
+on:
+  push:
+    branches:
+      - master
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "has conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
The typical use case is to run this action post merge (e.g. push to master) to quickly see which other PRs are now in conflict.